### PR TITLE
fix: colors in arbitration details

### DIFF
--- a/src/components/others/route_article/arbitrationDetails/index.module.scss
+++ b/src/components/others/route_article/arbitrationDetails/index.module.scss
@@ -1,8 +1,10 @@
 @use "src/stylesheets/variables/spacings";
 @use "src/stylesheets/variables/typo";
 
-$brownDarken40: hsla(var(--english-breakfast-800), 0.6);
-$brownDarken20: hsla(var(--english-breakfast-700), 0.6);
+
+
+
+
 $green: hsl(180, 46%, 15%);
 $pink: hsl(313, 74%, 35%);
 
@@ -23,12 +25,17 @@ $pink: hsl(313, 74%, 35%);
     justify-content: space-between;
     padding: spacings.$s-3 spacings.$s-4;
     margin-bottom: spacings.$s-7;
-    border: 1px solid $brownDarken40;
+    border: 1px solid var(--english-breakfast-900);
     border-radius: 4px;
+    box-shadow: inset 0.125rem 0.125rem 0.5rem 0 var(--starbright-700), 0rem 0.25rem 0.5rem 0 var(--starbright-700);
+    color: var(--english-breakfast-600);
+
+
 
     > span {
       b {
         margin-right: spacings.$s-2;
+        color:var(--dark-orchestra-600);
       }
     }
   }


### PR DESCRIPTION
unable to apply negative alpha values for hsla due to CSS custom properties
