### PR TITLE
Fixes issue 106

### DIFF
--- a/src/components/others/listArticles/index.jsx
+++ b/src/components/others/listArticles/index.jsx
@@ -30,9 +30,7 @@ export default function ListArticles({ articles, isFetching }) {
                 setArticleContents((prevState) => ({
                   ...prevState,
                   [article.articleID]: { title: data.title, description: data.description },
-                }));
-
-                setFetchingArticlesContents(false);
+                })).then(() => setFetchingArticlesContents(false));
               });
             },
             (err) => {


### PR DESCRIPTION
Simply, `setFetchingArticleContents` was being reset before the data loaded up. Fixed the problem by making `setFetchingArticlesContent` wait until `setArticleContents` finishes.
